### PR TITLE
Add ability to use custom font for titles and buttons

### DIFF
--- a/library/src/main/java/de/mrapp/android/dialog/MaterialDialogConfig.java
+++ b/library/src/main/java/de/mrapp/android/dialog/MaterialDialogConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 - 2016 Michael Rapp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package de.mrapp.android.dialog;
+
+import android.graphics.Typeface;
+
+/**
+ * Global dialog configurations. For now the title and button fonts can be set using
+ */
+public class MaterialDialogConfig {
+    private static Typeface titleFont = null;
+    private static Typeface buttonFont = null;
+
+    /**
+     * Set the title font for all dialogs created in the future.
+     *
+     * @param typeface
+     *         This font will be used for all titles in dialogs created in the future. Set to null
+     *         to use the default font.
+     */
+    public static void setTitleFont(Typeface typeface) {
+        titleFont = typeface;
+    }
+
+    /**
+     * Set the button font for all dialogs created in the future.
+     *
+     * @param typeface
+     *         This font will be used for buttons in dialogs created in the future. Set to null to
+     *         use the default font.
+     */
+    public static void setButtonFont(Typeface typeface) {
+        buttonFont = typeface;
+    }
+
+    /**
+     * Get the globally used title font for dialogs.
+     * 
+     * @return
+     *        globally used title font, null if set to use default
+     */
+    public static Typeface getTitleFont() {
+        return titleFont;
+    }
+
+    /**
+     * Get the globally used button font for dialogs.
+     *
+     * @return
+     *        globally used button font, null if set to use default
+     */
+    public static Typeface getButtonFont() {
+        return buttonFont;
+    }
+}

--- a/library/src/main/java/de/mrapp/android/dialog/decorator/ButtonBarDialogDecorator.java
+++ b/library/src/main/java/de/mrapp/android/dialog/decorator/ButtonBarDialogDecorator.java
@@ -15,6 +15,7 @@ package de.mrapp.android.dialog.decorator;
 
 import android.content.DialogInterface;
 import android.content.res.ColorStateList;
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.annotation.ColorInt;
 import android.support.annotation.NonNull;
@@ -28,6 +29,7 @@ import android.widget.Button;
 
 import java.util.Locale;
 
+import de.mrapp.android.dialog.MaterialDialogConfig;
 import de.mrapp.android.dialog.R;
 import de.mrapp.android.dialog.listener.OnClickListenerWrapper;
 import de.mrapp.android.dialog.model.ValidateableDialog;
@@ -245,54 +247,60 @@ public class ButtonBarDialogDecorator extends AbstractDialogDecorator<Validateab
     }
 
     /**
+     * Adapt a specific button
+     *
+     * @param button
+     *         the button to adapt
+     * @param buttonText
+     *         text displayed on the button
+     * @param listener
+     *         listener of the button
+     * @param identifier
+     *         type of button e.g. {@link DialogInterface#BUTTON_POSITIVE},
+     *         {@link DialogInterface#BUTTON_NEGATIVE}, or {@link DialogInterface#BUTTON_NEUTRAL}.
+     */
+    private void adaptButton(Button button, CharSequence buttonText,
+                             DialogInterface.OnClickListener listener, final int identifier) {
+        if (button != null) {
+            Typeface buttonFont = MaterialDialogConfig.getButtonFont();
+            if (buttonFont != null) {
+                button.setTypeface(buttonFont);
+            }
+
+            button.setText(buttonText != null ?
+                    buttonText.toString().toUpperCase(Locale.getDefault()) : null);
+            OnClickListenerWrapper onClickListener =
+                    new OnClickListenerWrapper(listener, true, getDialog(),
+                            DialogInterface.BUTTON_POSITIVE);
+            button.setOnClickListener(onClickListener);
+            button.setVisibility(!TextUtils.isEmpty(buttonText) ? View.VISIBLE : View.GONE);
+
+            adaptButtonBarContainerVisibility();
+        }
+    }
+
+    /**
      * Adapts the dialog's positive button.
      */
     private void adaptPositiveButton() {
-        if (positiveButton != null) {
-            positiveButton.setText(positiveButtonText != null ?
-                    positiveButtonText.toString().toUpperCase(Locale.getDefault()) : null);
-            OnClickListenerWrapper onClickListener =
-                    new OnClickListenerWrapper(positiveButtonListener, true, getDialog(),
-                            DialogInterface.BUTTON_POSITIVE);
-            positiveButton.setOnClickListener(onClickListener);
-            positiveButton.setVisibility(
-                    !TextUtils.isEmpty(positiveButtonText) ? View.VISIBLE : View.GONE);
-            adaptButtonBarContainerVisibility();
-        }
+        adaptButton(positiveButton, positiveButtonText, positiveButtonListener,
+                DialogInterface.BUTTON_POSITIVE);
     }
 
     /**
      * Adapts the dialog's neutral button.
      */
     private void adaptNeutralButton() {
-        if (neutralButton != null) {
-            neutralButton.setText(neutralButtonText != null ?
-                    neutralButtonText.toString().toUpperCase(Locale.getDefault()) : null);
-            OnClickListenerWrapper onClickListener =
-                    new OnClickListenerWrapper(neutralButtonListener, false, getDialog(),
-                            DialogInterface.BUTTON_NEUTRAL);
-            neutralButton.setOnClickListener(onClickListener);
-            neutralButton.setVisibility(
-                    !TextUtils.isEmpty(neutralButtonText) ? View.VISIBLE : View.GONE);
-            adaptButtonBarContainerVisibility();
-        }
+        adaptButton(neutralButton, neutralButtonText, neutralButtonListener,
+                DialogInterface.BUTTON_NEUTRAL);
     }
 
     /**
      * Adapts the dialog's negative button.
      */
     private void adaptNegativeButton() {
-        if (negativeButton != null) {
-            negativeButton.setText(negativeButtonText != null ?
-                    negativeButtonText.toString().toUpperCase(Locale.getDefault()) : null);
-            OnClickListenerWrapper onClickListener =
-                    new OnClickListenerWrapper(negativeButtonListener, false, getDialog(),
-                            DialogInterface.BUTTON_NEGATIVE);
-            negativeButton.setOnClickListener(onClickListener);
-            negativeButton.setVisibility(
-                    !TextUtils.isEmpty(negativeButtonText) ? View.VISIBLE : View.GONE);
-            adaptButtonBarContainerVisibility();
-        }
+        adaptButton(negativeButton, negativeButtonText, negativeButtonListener,
+                DialogInterface.BUTTON_NEGATIVE);
     }
 
     /**

--- a/library/src/main/java/de/mrapp/android/dialog/decorator/MaterialDialogDecorator.java
+++ b/library/src/main/java/de/mrapp/android/dialog/decorator/MaterialDialogDecorator.java
@@ -15,6 +15,7 @@ package de.mrapp.android.dialog.decorator;
 
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
+import android.graphics.Typeface;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
@@ -33,6 +34,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import de.mrapp.android.dialog.MaterialDialogConfig;
 import de.mrapp.android.dialog.R;
 import de.mrapp.android.dialog.model.Dialog;
 import de.mrapp.android.util.ViewUtil;
@@ -322,6 +324,7 @@ public class MaterialDialogDecorator extends AbstractDialogDecorator<Dialog>
             inflateTitleView();
             adaptTitle();
             adaptTitleColor();
+            adaptTitleFont();
             adaptIcon();
         }
     }
@@ -343,6 +346,16 @@ public class MaterialDialogDecorator extends AbstractDialogDecorator<Dialog>
     private void adaptTitleColor() {
         if (titleTextView != null) {
             titleTextView.setTextColor(titleColor);
+        }
+    }
+
+    /**
+     * Adapts the dialog's title font
+     */
+    private void adaptTitleFont() {
+        Typeface titleFont = MaterialDialogConfig.getTitleFont();
+        if (titleFont != null) {
+            titleTextView.setTypeface(titleFont);
         }
     }
 
@@ -672,6 +685,7 @@ public class MaterialDialogDecorator extends AbstractDialogDecorator<Dialog>
         inflateContentView();
         adaptTitle();
         adaptTitleColor();
+        adaptTitleFont();
         adaptIcon();
         adaptMessage();
         adaptMessageColor();


### PR DESCRIPTION
Hi,

I noticed that it wasn't that easy as I thought to use the medium font as `sans-serif-medium` only became available on Lollipop.

After long and hard thinking I was able to come up with a solution I think is OK at least. I tried to follow your guidelines as much as I could.

I added a new class `MaterialDialogConfig`. This class handles global settings, for example I would probably want to apply the font to all dialogs. I wasn't sure if I was to create this class or add this functionality in an already existing class. What do you prefer?

`MaterialDialogConfig` has two methods: `setTitleFont(Typeface)` and `setButtonFont(Typeface)`. I didn't want to include the font-file as it would take up space that most people wouldn't use anyway.

The font is set in `ButtonBarDialogDescriptor` and `MaterialDialogDescriptor`.

I also refactored `updatePositive/Negative/NeutralButton()` and added `updateButton()` that takes arguments that are needed for updating buttons. That way you only have to change things in one place. If you rather have it as it was before I can revert it :)

Any changes you want me to make?

EDIT: Forgot to mention that I've tested the code and it works ;)
